### PR TITLE
Switch render_to_response > render

### DIFF
--- a/django_databrowse/plugins/calendars.py
+++ b/django_databrowse/plugins/calendars.py
@@ -2,7 +2,7 @@ from django import http
 from django.db import models
 from django_databrowse.datastructures import EasyModel
 from django_databrowse.sites import DatabrowsePlugin
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.utils.text import capfirst
 from django.utils.encoding import force_unicode
 from django.utils.safestring import mark_safe
@@ -108,13 +108,14 @@ class CalendarPlugin(DatabrowsePlugin):
         easy_model = EasyModel(self.site, self.model)
         field_list = self.fields.values()
         field_list.sort(key=lambda k:k.verbose_name)
-        return render_to_response(
+        return render(
+            request,
             'databrowse/calendar_homepage.html',
             {
                 'root_url': self.site.root_url,
                 'model': easy_model,
                 'field_list': field_list
-            }, {}
+            }
         )
 
     def calendar_view(self, request, field, year=None, month=None, day=None):

--- a/django_databrowse/plugins/fieldchoices.py
+++ b/django_databrowse/plugins/fieldchoices.py
@@ -2,7 +2,7 @@ from django import http
 from django.db import models
 from django_databrowse.datastructures import EasyModel
 from django_databrowse.sites import DatabrowsePlugin
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.utils.text import capfirst
 from django.utils.encoding import smart_str, force_unicode
 from django.utils.safestring import mark_safe
@@ -83,13 +83,14 @@ class FieldChoicePlugin(DatabrowsePlugin):
         easy_model = EasyModel(self.site, self.model)
         field_list = self.fields.values()
         field_list.sort(key=lambda k: k.verbose_name)
-        return render_to_response(
+        return render(
+            request,
             'databrowse/fieldchoice_homepage.html',
             {
                 'root_url': self.site.root_url,
                 'model': easy_model,
                 'field_list': field_list
-            }, {}
+            }
         )
 
     def field_view(self, request, field, value=None):
@@ -122,7 +123,8 @@ class FieldChoicePlugin(DatabrowsePlugin):
             obj_list_page = paginator.page(paginator.num_pages)
         
         if value is not None:
-            return render_to_response(
+            return render(
+                request,
                 'databrowse/fieldchoice_detail.html',
                 {
                     'root_url': self.site.root_url,
@@ -131,10 +133,11 @@ class FieldChoicePlugin(DatabrowsePlugin):
                     'value': value,
                     'object_list': obj_list_page,
                     'items_per_page': items_per_page,
-                }, {}
+                }
             )
 
-        return render_to_response(
+        return render(
+            request,
             'databrowse/fieldchoice_list.html',
             {
                 'root_url': self.site.root_url,
@@ -142,5 +145,5 @@ class FieldChoicePlugin(DatabrowsePlugin):
                 'field': easy_field,
                 'object_list': obj_list_page,
                 'items_per_page': items_per_page,
-            }, {}
+            }
         )

--- a/django_databrowse/plugins/objects.py
+++ b/django_databrowse/plugins/objects.py
@@ -2,8 +2,9 @@ from django import http
 from django.core.exceptions import ObjectDoesNotExist
 from django_databrowse.datastructures import EasyModel
 from django_databrowse.sites import DatabrowsePlugin
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 import urlparse
+
 
 class ObjectDetailPlugin(DatabrowsePlugin):
     def model_view(self, request, model_databrowse, url):
@@ -23,10 +24,11 @@ class ObjectDetailPlugin(DatabrowsePlugin):
             raise http.Http404('Id not found')
         except ValueError, e:
             raise http.Http404('Invalid format key provided')
-        return render_to_response(
+        return render(
+            request,
             'databrowse/object_detail.html',
             {
                 'object': obj,
                 'root_url': model_databrowse.site.root_url
-            }, {}
+            }
         )

--- a/django_databrowse/sites.py
+++ b/django_databrowse/sites.py
@@ -5,7 +5,7 @@ try:
 except ImportError, e:
     from django.db.models import get_model
 
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.utils.safestring import mark_safe
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
@@ -98,7 +98,8 @@ class ModelDatabrowse(object):
         except EmptyPage:
             # If page is out of range (e.g. 9999), deliver last page.
             obj_list_page = paginator.page(paginator.num_pages)
-        return render_to_response(
+        return render(
+            request,
             'databrowse/model_detail.html',
             {
                 'model': easy_model,
@@ -106,7 +107,7 @@ class ModelDatabrowse(object):
                 'plugin_html': html_snippets,
                 'object_list': obj_list_page,
                 'items_per_page': items_per_page,
-            }, {}
+            }
         )
 
 
@@ -164,10 +165,10 @@ class DatabrowseSite(object):
 
     def index(self, request):
         m_list = [EasyModel(self, m) for m in self.registry.keys()]
-        return render_to_response(
+        return render(
+            request,
             'databrowse/homepage.html',
-            {'model_list': m_list, 'root_url': self.root_url},
-            {}
+            {'model_list': m_list, 'root_url': self.root_url}
         )
 
     def model_page(self, request, app_label, model_name, rest_of_url=None):

--- a/django_databrowse/views.py
+++ b/django_databrowse/views.py
@@ -1,5 +1,5 @@
 from django.http import Http404
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 ###########
@@ -8,9 +8,10 @@ from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 def choice_list(request, app_label, model_name, field_name, models):
     m, f = lookup_field(app_label, model_name, field_name, models)
-    return render_to_response(
+    return render(
+        request,
         'databrowse/choice_list.html',
-        {'model': m, 'field': f}, {}
+        {'model': m, 'field': f}
     )
 
 def choice_detail(request, app_label, model_name, field_name,
@@ -39,7 +40,8 @@ def choice_detail(request, app_label, model_name, field_name,
         # If page is out of range (e.g. 9999), deliver last page.
         obj_list_page = paginator.page(paginator.num_pages)
 
-    return render_to_response(
+    return render(
+        request,
         'databrowse/choice_detail.html',
         {
             'model': m,
@@ -47,5 +49,5 @@ def choice_detail(request, app_label, model_name, field_name,
             'value': label,
             'object_list': obj_list_page,
             'items_per_page': items_per_page,
-        }, {}
+        }
     )


### PR DESCRIPTION
Switch to the `render` function to ensure the context processor information is available to the templates.