### PR TITLE
__str__ must return a string, not bytes

### DIFF
--- a/django_databrowse/datastructures.py
+++ b/django_databrowse/datastructures.py
@@ -126,7 +126,7 @@ class EasyInstance(object):
         return val
 
     def __str__(self):
-        return self.__unicode__().encode('utf-8')
+        return self.__unicode__()
 
     def pk(self):
         return self.instance._get_pk_val()


### PR DESCRIPTION
This causes an error in Python 3.7 + Django 1.11.